### PR TITLE
Fix key export file path issue for cross-platform compatibility in test

### DIFF
--- a/cipherface/__init__.py
+++ b/cipherface/__init__.py
@@ -48,7 +48,7 @@ class CipherFace:
             "VGG-Face",
             "Facenet",
             "Facenet512",
-        ], f"Unsppoted model {self.facial_recognition_model}"
+        ], f"Unsupported model {self.facial_recognition_model}"
 
         self.face_detector = face_detector
         assert self.face_detector in [

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,11 +1,18 @@
 # built-in dependencies
 import pytest
+import tempfile
+import os
 
 # project dependencies
 from cipherface import CipherFace
 from cipherface.commons.logger import Logger
 
 logger = Logger(__name__)
+
+
+temp_dir = tempfile.gettempdir()  # system's temp directory
+private_key_path = os.path.join(temp_dir, "private.txt")
+public_key_path = os.path.join(temp_dir, "public.txt")
 
 
 def test_e2e():
@@ -29,14 +36,14 @@ def test_e2e():
                     database[img_path] = embedding
                     break
 
-            onprem.export_private_key("/tmp/private.txt")
-            onprem.export_public_key("/tmp/public.txt")
+            onprem.export_private_key(private_key_path)
+            onprem.export_public_key(public_key_path)
 
             # cloud uses public key to securely embed the image
             cloud = CipherFace(
                 facial_recognition_model=model_name,
                 distance_metric=distance_metric,
-                cryptosystem="/tmp/public.txt",
+                cryptosystem=public_key_path,
             )
 
             target_path = "dataset/target.jpg"
@@ -67,6 +74,6 @@ def test_e2e():
                 )
                 assert (
                     is_verified is expected_classifications[idx]
-                ), f"{img_path} is misclassified. Expexted {expected_classifications[idx]}, but got {is_verified}"
+                ), f"{img_path} is misclassified. Expected {expected_classifications[idx]}, but got {is_verified}"
 
             logger.info(f"✅ e2e euclidean test done for {model_name} - {distance_metric}")


### PR DESCRIPTION
This PR fixes a ``FileNotFoundError`` occurring in the test code due to hardcoded file paths for key export ``/tmp/private.txt`` and ``/tmp/public.txt``. Since the original paths didn't work on Windows, I modified the code to dynamically fetch the system's temporary directory path. This ensures the test can run successfully across different operating systems, including Windows, by using the system's default temp directory for storing key files.

Additionally, I’ve fixed a few minor typos in the codebase for better clarity and readability.

Test result on Windows system

```
25-02-23 13:53:52 - ✅ e2e euclidean test done for VGG-Face - euclidean
25-02-23 13:54:03 - ✅ e2e euclidean test done for VGG-Face - cosine
25-02-23 13:54:18 - ✅ e2e euclidean test done for Facenet - euclidean
25-02-23 13:54:28 - ✅ e2e euclidean test done for Facenet - cosine
25-02-23 13:54:43 - ✅ e2e euclidean test done for Facenet512 - euclidean
25-02-23 13:54:55 - ✅ e2e euclidean test done for Facenet512 - cosine
```

Test result on Ubuntu (WSL2) system

```
25-02-23 15:03:11 - ✅ e2e euclidean test done for VGG-Face - euclidean
25-02-23 15:03:19 - ✅ e2e euclidean test done for VGG-Face - cosine
25-02-23 15:03:45 - ✅ e2e euclidean test done for Facenet - euclidean
25-02-23 15:03:54 - ✅ e2e euclidean test done for Facenet - cosine
25-02-23 15:04:12 - ✅ e2e euclidean test done for Facenet512 - euclidean
25-02-23 15:04:22 - ✅ e2e euclidean test done for Facenet512 - cosine
```
